### PR TITLE
Export types used in public methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,12 @@
+export type { 
+  ImageAttrs, 
+  Multiscale, 
+  Axis, 
+  Dataset, 
+  Omero, 
+  Channel, 
+  Window 
+} from "./types/ome";
 export {
   getArray,
   getMultiscale,


### PR DESCRIPTION
This PR addresses #6 by exporting the types in `types/ome.ts` as part of the public interface. Here is what is changed after building the distribution:

```bash
$ diff -r dist_orig/ dist/
diff -r dist_orig/ome-zarr.d.ts dist/ome-zarr.d.ts
8c8
< declare interface Axis {
---
> export declare interface Axis {
18c18
< declare interface Channel {
---
> export declare interface Channel {
30c30
< declare interface Dataset {
---
> export declare interface Dataset {
63a64,79
> /**
>  * Model for the metadata of OME-Zarr data.
>  *
>  * See https://ngff.openmicroscopy.org/0.4/#image-layout.
>  */
> export declare interface ImageAttrs {
>     /**
>      * The multiscale datasets for this image
>      *
>      * @minItems 1
>      */
>     multiscales: [Multiscale, ...Multiscale[]];
>     omero?: Omero | null;
>     [k: string]: unknown;
> }
>
73c89
< declare interface Multiscale {
---
> export declare interface Multiscale {
94c110
< declare interface Omero {
---
> export declare interface Omero {
127a144
> export { Window_2 as Window }
```
