### PR TITLE
fix: Define path to types in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
       "import": "./dist/ome-zarr.js"
     }
   },
+  "types": "./dist/ome-zarr.d.ts",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
I was using `ome-zarr.js` in a project, and I was getting a Typescript error when trying to import it.

The import:
```ts
import { renderThumbnail } from "ome-zarr.js";
```

The error:
```txt
Cannot find module 'ome-zarr.js' or its corresponding type declarations.
  There are types at '[...]/node_modules/ome-zarr.js/dist/ome-zarr.d.ts', but this result could not be resolved 
  under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.ts(2307)
```

I was able to fix it by adding an explicit `types` path in the `package.json` to the built types file.