### PR TITLE
Render dataset index

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,8 +227,12 @@
         }
       }
 
-      let thumbSrc = await omezarr.render(IDR0066, 300);
+      let thumbSrc = await omezarr.render(IDR0066, undefined, {datasetIndex: 7});
       let bigImg = `<img src="${thumbSrc}" />`;
+      document.getElementById("bigThumbnails").innerHTML += bigImg;
+
+      thumbSrc = await omezarr.render(IDR0066, undefined, {datasetIndex: 6});
+      bigImg = `<img src="${thumbSrc}" />`;
       document.getElementById("bigThumbnails").innerHTML += bigImg;
       // legacy API - keep a single test for this...
       thumbSrc = await omezarr.renderThumbnail(IDR0066, 300, true);

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,18 +14,18 @@ export async function render(
     maxSize?: number,
     attrs?: OmeAttrs,
     signal?: AbortSignal,
+    datasetIndex?: number,
   } = {},
 ): Promise<string> {
   
   const { signal } = options ?? {};
   signal?.throwIfAborted();
-  let arrayPathOrIndex: number | undefined = undefined;
+  let datasetIndex = options.datasetIndex ?? -1;
   let ngffImg: NgffImage;
 
   // If no targetSize, we ONLY load the smallest array, and render same array below...
   if (targetSize == undefined) {
-    arrayPathOrIndex = -1;
-    ngffImg = await NgffImage.load(store, {datasetIndex: arrayPathOrIndex, attrs: options.attrs});
+    ngffImg = await NgffImage.load(store, {datasetIndex: datasetIndex, attrs: options.attrs});
   } else {
     // ...but if we know the targetSize, we load the largest array here (default),
     // then use targetSize below to pick right resolution
@@ -47,7 +47,7 @@ export async function render(
 
   let src = await ngffImg.render({
     targetSize,
-    arrayPathOrIndex,
+    arrayPathOrIndex: datasetIndex,
     autoBoost: options.autoBoost,
     maxSize: options.maxSize});
   return src;

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,11 +20,12 @@ export async function render(
   
   const { signal } = options ?? {};
   signal?.throwIfAborted();
-  let datasetIndex = options.datasetIndex ?? -1;
+  let datasetIndex: number | undefined;
   let ngffImg: NgffImage;
 
-  // If no targetSize, we ONLY load the smallest array, and render same array below...
+  // If no targetSize, we ONLY load the specified/smallest array, and render same array below...
   if (targetSize == undefined) {
+    datasetIndex = options.datasetIndex ?? -1
     ngffImg = await NgffImage.load(store, {datasetIndex: datasetIndex, attrs: options.attrs});
   } else {
     // ...but if we know the targetSize, we load the largest array here (default),

--- a/tests/renderThumbnail.node.test.js
+++ b/tests/renderThumbnail.node.test.js
@@ -62,6 +62,15 @@ describe("render", () => {
       })
     ).rejects.toThrow();
   }, 10_000); // timeout in ms
+
+  test("render6001240_datasetIndex", async () => {
+    let result0 = await render(URL_IDR62, undefined, {datasetIndex: 0});
+    let result1 = await render(URL_IDR62, undefined, {datasetIndex: 1});
+    let result2 = await render(URL_IDR62, undefined, {datasetIndex: 2});
+    // We can't compare exact values, but this checks that datasetIndex is respected.
+    expect(result0.length).toBeGreaterThan(result1.length);
+    expect(result1.length).toBeGreaterThan(result2.length);
+  }, 10_000); // timeout in ms
 });
 
 test("version6001240", async () => {


### PR DESCRIPTION
Adds an option to specify `datasetIndex` in `render()` as needed at https://github.com/ome/ome2024-ngff-challenge/pull/108

cc @lubianat 