### PR TITLE
update bia urls to livingobjects

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -58,7 +58,7 @@ will be created.
 
 ```js
 // We create a NgffImage, update rendering settings and render()
-let url = "https://livingobjects.ebi.ac.uk/bia-integrator-data/S-BIAD855/781ac3d7-673f-47be-a4d2-3fdf3f477047/781ac3d7-673f-47be-a4d2-3fdf3f477047.zarr/D/3/0";
+let url = "https://livingobjects.ebi.ac.uk/bioimaging-integrator-data/S-BIAD855/781ac3d7-673f-47be-a4d2-3fdf3f477047/781ac3d7-673f-47be-a4d2-3fdf3f477047.zarr/D/3/0";
 
 // When the image is loaded, default rendering settings are created
 // if there is no "omero" metadata found
@@ -84,7 +84,7 @@ documentation](https://github.com/biongff/ome-zarr.js/blob/main/docs/components/
 The example below is from [ImageViewer](https://github.com/biongff/ome-zarr.js/blob/main/docs/components/ImageViewer.vue) component.
 
 <ClientOnly>
-<ImageViewer url="https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD855/781ac3d7-673f-47be-a4d2-3fdf3f477047/781ac3d7-673f-47be-a4d2-3fdf3f477047.zarr/D/3/0" />
+<ImageViewer url="https://livingobjects.ebi.ac.uk/bioimaging-integrator-data/S-BIAD855/781ac3d7-673f-47be-a4d2-3fdf3f477047/781ac3d7-673f-47be-a4d2-3fdf3f477047.zarr/D/3/0" />
 </ClientOnly>
 
 Image is from [idr0036-gustafsdottir-cellpainting](https://idr.openmicroscopy.org/webclient/?show=screen-1952).

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     <script type="module">
 
       async function renderSimilarThumbs() {
-        let plateUrl = "https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD885/e7bdccbf-5119-4d9c-b466-66d211871db8/e7bdccbf-5119-4d9c-b466-66d211871db8.zarr";
+        let plateUrl = "https://livingobjects.ebi.ac.uk/bioimaging-integrator-data/S-BIAD885/e7bdccbf-5119-4d9c-b466-66d211871db8/e7bdccbf-5119-4d9c-b466-66d211871db8.zarr";
         let a1Img = await omezarr.NgffImage.load(plateUrl + "/A/1/0");
         // a1Img.omero.channels[0].active = false;
         let dsPath = await a1Img.getPathForTargetSize(100);


### PR DESCRIPTION
Update livingobjects urls to bia bucket.

To test, check new URLs are valid in validator

E.g. https://ome.github.io/ome-ngff-validator/?source=https://livingobjects.ebi.ac.uk/bioimaging-integrator-data/S-BIAD855/781ac3d7-673f-47be-a4d2-3fdf3f477047/781ac3d7-673f-47be-a4d2-3fdf3f477047.zarr/D/3/0