### PR TITLE
Fix typo in renderRgbDataToDataUrl

### DIFF
--- a/docs/components/Labels.vue
+++ b/docs/components/Labels.vue
@@ -37,7 +37,7 @@ onMounted(async () => {
   blackToTransparentRgba(labelRgba.data);
 
   // convert the rgba array back to image src
-  labelSrc.value = await omezarr.convertRbgDataToDataUrl(
+  labelSrc.value = await omezarr.convertRgbDataToDataUrl(
     labelRgba.data,
     labelRgba.width
   );

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -35,7 +35,7 @@ let {data, width} = await img.renderRgba({targetSize: 300);
 blackToTransparentRgba(data)
 
 // convert the rgba array back to image src
-let labelSrc = await omezarr.convertRbgDataToDataUrl(data, width);
+let labelSrc = await omezarr.convertRgbDataToDataUrl(data, width);
 document.getElementById("labelImg").src = labelSrc;
 ```
 

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
         let labelRgba = await labelImage.renderRgba({targetSize: 300});
         blackToTransparentRgba(labelRgba.data);
 
-        let labelSrc = await omezarr.convertRbgDataToDataUrl(labelRgba.data, labelRgba.width);
+        let labelSrc = await omezarr.convertRgbDataToDataUrl(labelRgba.data, labelRgba.width);
         html = `<a href="${imgUrl}labels/${labelPaths[0]}"><img class="checquers" src="${labelSrc}" /></a>`;
         document.getElementById("labels").innerHTML += html;
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,7 @@
 import * as zarr from "zarrita";
 
 import { Axis, Channel, OmeAttrs, Omero } from "./types/ome";
-import { getRgba, convertRbgDataToDataUrl } from "./render";
+import { getRgba, convertRgbDataToDataUrl } from "./render";
 import { NgffImage } from "./image";
 
 
@@ -84,5 +84,5 @@ export async function renderImage(
     originalShape,
     autoBoost
   );
-  return convertRbgDataToDataUrl(data, width);
+  return convertRgbDataToDataUrl(data, width);
 }

--- a/src/image.ts
+++ b/src/image.ts
@@ -3,7 +3,7 @@ import * as zarr from "zarrita";
 import { ImageAttrs, ImageAttrsV5, OmeAttrs, Multiscale, Omero, Axis } from "./types/ome";
 import { openArray, openGroup, createOmero } from "./utils";
 // import { renderImage } from "./api";
-import { convertRbgDataToDataUrl, getRgba } from "./render";
+import { convertRgbDataToDataUrl, getRgba } from "./render";
 import { generateNeuroglancerStateForOmeZarr, LayerType } from "./helper";
 
 export class NgffImage {
@@ -441,6 +441,6 @@ export class NgffImage {
   ): Promise<string> {
 
     let { data, width } = await this.renderRgba(options);
-    return convertRbgDataToDataUrl(data, width);
+    return convertRgbDataToDataUrl(data, width);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,4 +21,4 @@ export {
 export { LUTS, getLuts } from "./luts";
 export { NgffImage } from "./image";
 export { renderThumbnail, renderImage, render } from "./api";
-export { convertRbgDataToDataUrl } from "./render";
+export { convertRgbDataToDataUrl } from "./render";

--- a/src/render.ts
+++ b/src/render.ts
@@ -135,7 +135,7 @@ export async function getRgba(
   return { data, width, height };
 }
 
-export async function convertRbgDataToDataUrl(
+export async function convertRgbDataToDataUrl(
   rbgData: Uint8ClampedArray,
   width: number
 ): Promise<string> {


### PR DESCRIPTION
Method was added in 87998dc62b1f1bbaed0e8fba542257d1b83a864a for internal testing purposes.
Only just noticed by @jwindhager but not knowingly used in any external libs.

So I think it's OK to just go ahead and rename.

@jwindhager OK to get this in ahead of your PR? Then we can merge/rebase yours on top?