### PR TITLE
rename renderRgba() to renderArray()

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,7 @@
 import * as zarr from "zarrita";
 
 import { Axis, Channel, OmeAttrs } from "./types/ome";
-import { renderRgba } from "./render";
+import { renderArray } from "./render";
 import { NgffImage } from "./image";
 import { createRgbDataUrl } from "./utils";
 
@@ -76,7 +76,7 @@ export async function renderImage(
   sliceIndices: { [k: string]: number | [number, number] | undefined } = {},
   autoBoost: boolean = false
 ): Promise<string> {
-  let { data, width } = await renderRgba(
+  let { data, width } = await renderArray(
     arr,
     axes,
     channels,

--- a/src/image.ts
+++ b/src/image.ts
@@ -2,7 +2,7 @@
 import * as zarr from "zarrita";
 import { ImageAttrs, ImageAttrsV5, OmeAttrs, Multiscale, Omero, Axis, Channel, Color } from "./types/ome";
 import { createRgbDataUrl, openArray, openGroup, createOmero } from "./utils";
-import { renderRgba } from "./render";
+import { renderArray } from "./render";
 import { generateNeuroglancerStateForOmeZarr, LayerType } from "./helper";
 
 export class NgffImage {
@@ -372,7 +372,7 @@ export class NgffImage {
     return path;
   }
 
-  async renderRgba(options: {
+  async renderArray(options: {
     // Array can be provided directly, or we will load based on targetSize or arrayPathOrIndex
     arr?: zarr.Array<any> | string,
     targetSize?: number,
@@ -452,7 +452,7 @@ export class NgffImage {
       calcMinMaxForRange = options.calcMinMaxForRange;
     }
 
-    let { data, width, height } = await renderRgba(
+    let { data, width, height } = await renderArray(
       arr,
       this.axes,
       channels,
@@ -477,7 +477,7 @@ export class NgffImage {
     calcMinMaxForRange?: boolean
   } = {}
   ): Promise<string> {
-    let { data, width } = await this.renderRgba(options);
+    let { data, width } = await this.renderArray(options);
     return createRgbDataUrl(data, width);
   }
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -124,7 +124,7 @@ export function renderChunkWithColormap(
   return renderChunk(chunk, transferFunc, { dst, blending });
 }
 
-export async function renderRgba(
+export async function renderArray(
   arr: zarr.Array<any, zarr.Readable>,
   axes: Axis[],
   channels: Channel[] | null | undefined,


### PR DESCRIPTION
Simply renames `renderRgba()` to `renderArray()` as discussed at https://github.com/BioNGFF/ome-zarr.js/pull/33#issuecomment-4564970752

cc @jwindhager 